### PR TITLE
feat: clean up prediction market UI and enforce binary-only filtering

### DIFF
--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { prisma, Category } from "@mintfeed/db";
-import { DEFAULT_PAGE_SIZE } from "@mintfeed/shared";
+import { DEFAULT_PAGE_SIZE, isBinaryMarket } from "@mintfeed/shared";
 
 export const feedRoutes = new Hono();
 
@@ -27,9 +27,11 @@ const ARTICLE_SELECT_WITH_PREDICTIONS = {
         select: {
           id: true,
           question: true,
+          outcomes: true,
           outcomePrices: true,
           marketUrl: true,
           volume: true,
+          endDate: true,
         },
       },
     },
@@ -45,13 +47,14 @@ function mapArticle(article: ArticleWithPredictions) {
   const seen = new Set<string>();
   const markets = predictionMarkets
     .map((link) => link.predictionMarket)
+    .filter((m) => isBinaryMarket(m.outcomes))
     .sort((a, b) => b.volume - a.volume)
     .filter((m) => {
       if (seen.has(m.question)) return false;
       seen.add(m.question);
       return true;
     })
-    .map(({ volume: _v, ...m }) => m);
+    .map(({ outcomes: _, ...m }) => ({ ...m, endDate: m.endDate?.toISOString() ?? null }));
   return {
     ...rest,
     predictionMarkets: markets,
@@ -125,9 +128,11 @@ feedRoutes.get("/feed/:id", async (c) => {
               select: {
                 id: true,
                 question: true,
+                outcomes: true,
                 outcomePrices: true,
                 marketUrl: true,
                 volume: true,
+                endDate: true,
               },
             },
           },
@@ -143,13 +148,14 @@ feedRoutes.get("/feed/:id", async (c) => {
     const seen = new Set<string>();
     const markets = predictionMarkets
       .map((link) => link.predictionMarket)
+      .filter((m) => isBinaryMarket(m.outcomes))
       .sort((a, b) => b.volume - a.volume)
       .filter((m) => {
         if (seen.has(m.question)) return false;
         seen.add(m.question);
         return true;
       })
-      .map(({ volume: _v, ...m }) => m);
+      .map(({ outcomes: _, ...m }) => ({ ...m, endDate: m.endDate?.toISOString() ?? null }));
     return c.json({
       ...rest,
       predictionMarkets: markets,

--- a/apps/api/src/routes/predictions.ts
+++ b/apps/api/src/routes/predictions.ts
@@ -26,7 +26,11 @@ export const predictionRoutes = new Hono();
 
 predictionRoutes.get("/predictions/markets/:marketId", async (c) => {
   const { marketId } = c.req.param();
-  const data = await jupiter.get(`markets/${marketId}`).json();
+  const data = await jupiter.get(`markets/${marketId}`).json<any>();
+  // Reject non-binary markets
+  if (!data?.pricing || data.pricing.buyYesPriceUsd <= 0 || data.pricing.buyNoPriceUsd <= 0) {
+    return c.json({ error: "Market is not a binary Yes/No market" }, 404);
+  }
   return c.json(data);
 });
 

--- a/apps/api/src/services/jupiter-prediction.service.ts
+++ b/apps/api/src/services/jupiter-prediction.service.ts
@@ -126,6 +126,9 @@ export async function matchMarketForArticle(
         continue;
       }
 
+      // Only binary events — single-market events are true Yes/No questions
+      if (fullEvent.markets.length !== 1) continue;
+
       for (const market of fullEvent.markets) {
         if (market.status !== "open") continue;
         if (existingIds.has(market.marketId)) continue;
@@ -274,6 +277,15 @@ export async function refreshMarketPrices(): Promise<void> {
       const fresh = await jupiterClient
         .get(`markets/${market.id}`)
         .json<JupiterMarket>();
+
+      // Skip if market lost binary pricing
+      if (!fresh.pricing || fresh.pricing.buyYesPriceUsd <= 0 || fresh.pricing.buyNoPriceUsd <= 0) {
+        await prisma.predictionMarket.update({
+          where: { id: market.id },
+          data: { closed: true },
+        });
+        continue;
+      }
 
       const outcomePrices = buildOutcomePrices(fresh.pricing);
       const hasValidPrices = Object.values(outcomePrices).some((v) => v > 0);

--- a/apps/mobile/app/market-sheet/[id].tsx
+++ b/apps/mobile/app/market-sheet/[id].tsx
@@ -16,10 +16,8 @@ import { useAppStore } from "@/lib/store";
 import { mwaAuthorize } from "@/lib/wallet-adapter";
 import { colors } from "@/constants/theme";
 import { fonts, fontSize, letterSpacing } from "@/constants/typography";
-import { usePredictionMarketDetail, usePredictionOrderbook } from "@/hooks/usePredictionMarket";
+import { usePredictionMarketDetail } from "@/hooks/usePredictionMarket";
 import { useCreateOrder, useTradingStatus } from "@/hooks/usePredictionTrading";
-import { usePredictionOrders } from "@/hooks/usePredictionOrders";
-import { OrderRow } from "@/components/predict/OrderRow";
 import {
   microToUsd,
   usdToMicro,
@@ -27,6 +25,7 @@ import {
   validateTradeAmount,
   parseTradeAmount,
   formatResolutionCountdown,
+  computeLiquiditySpread,
   MINIMUM_TRADE_USD,
 } from "@mintfeed/shared";
 
@@ -45,10 +44,8 @@ export default function MarketSheet() {
   const themeColors = colors[theme];
 
   const { data: market, isLoading: marketLoading } = usePredictionMarketDetail(marketId);
-  const { data: orderbook } = usePredictionOrderbook(marketId);
   const createOrder = useCreateOrder();
   const { data: tradingStatus } = useTradingStatus();
-  const { data: ordersData } = usePredictionOrders(walletAddress ?? undefined);
 
   const [selectedSide, setSelectedSide] = useState<"yes" | "no">("yes");
   const [amount, setAmount] = useState("");
@@ -67,11 +64,6 @@ export default function MarketSheet() {
     if (price <= 0) return 0;
     return Math.floor(usd / price);
   }, [amount, selectedSide, yesPrice, noPrice]);
-
-  const userOrders = useMemo(() => {
-    if (!ordersData?.data || !marketId) return [];
-    return ordersData.data.filter((o) => o.marketId === marketId);
-  }, [ordersData, marketId]);
 
   const handleConnectWallet = useCallback(async () => {
     try {
@@ -111,24 +103,6 @@ export default function MarketSheet() {
     }
   }, [walletAddress, marketId, amount, selectedSide, createOrder]);
 
-  // Orderbook data
-  const orderbookRows = useMemo(() => {
-    if (!orderbook) return [];
-    const yBids = (orderbook.yes_dollars ?? []).slice(0, 5);
-    const nBids = (orderbook.no_dollars ?? []).slice(0, 5);
-    const maxLen = Math.max(yBids.length, nBids.length);
-    const rows: Array<{ yQty: number; yPrice: string; nPrice: string; nQty: number }> = [];
-    for (let i = 0; i < maxLen; i++) {
-      rows.push({
-        yQty: yBids[i]?.[1] ?? 0,
-        yPrice: yBids[i]?.[0] ?? "",
-        nPrice: nBids[i]?.[0] ?? "",
-        nQty: nBids[i]?.[1] ?? 0,
-      });
-    }
-    return rows;
-  }, [orderbook]);
-
   const isTradingPaused = tradingStatus?.trading_active === false;
   const hasAmountInput = amount.length > 0;
   const isAmountInvalid = hasAmountInput && !tradeValidation.valid;
@@ -146,6 +120,8 @@ export default function MarketSheet() {
     return `Buy ${selectedSide.toUpperCase()} \u00B7 ${selectedSide === "yes" ? yesPercent : noPercent}\u00A2`;
   }, [isTradingPaused, hasAmountInput, tradeValidation, selectedSide, yesPercent, noPercent]);
 
+  const isBinary = market && yesPrice > 0 && noPrice > 0;
+
   if (marketLoading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: themeColors.background }]}>
@@ -156,7 +132,26 @@ export default function MarketSheet() {
     );
   }
 
-  const marketTitle = market?.metadata.title ?? question ?? "Market";
+  if (market && !isBinary) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: themeColors.background }]}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} hitSlop={12} style={styles.headerButton}>
+            <Ionicons name="close" size={24} color={themeColors.text} />
+          </Pressable>
+          <View style={{ flex: 1 }} />
+        </View>
+        <View style={styles.loadingContainer}>
+          <Ionicons name="alert-circle-outline" size={32} color={themeColors.textMuted} />
+          <Text style={[styles.emptyText, { color: themeColors.textMuted, marginTop: 12 }]}>
+            Market unavailable
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const marketTitle = question ?? market?.metadata.title ?? "Market";
   const marketStatus = market?.status ?? "open";
   const statusColor = STATUS_COLORS[marketStatus] ?? STATUS_COLORS.open;
 
@@ -191,13 +186,6 @@ export default function MarketSheet() {
             </Text>
           </View>
         </View>
-
-        {/* Rules section */}
-        {market?.metadata.rulesPrimary ? (
-          <Text style={[styles.rulesText, { color: themeColors.textSecondary }]}>
-            {market.metadata.rulesPrimary}
-          </Text>
-        ) : null}
 
         {/* YES / NO probabilities */}
         <View style={styles.probRow}>
@@ -237,6 +225,8 @@ export default function MarketSheet() {
           <View style={[styles.fullBarNo, { flex: noPercent || 1, backgroundColor: themeColors.negative }]} />
         </View>
 
+        {/* TODO: Probability history chart — requires PredictionPriceSnapshot table + cron + new API endpoint */}
+
         {/* Resolution countdown + Volume */}
         {market && (
           <View style={styles.metaSection}>
@@ -269,44 +259,15 @@ export default function MarketSheet() {
           </View>
         )}
 
-        {/* Orderbook */}
-        {orderbookRows.length > 0 && (
-          <View style={[styles.orderbookSection, { backgroundColor: themeColors.card }]}>
-            <Text style={[styles.sectionTitle, { color: themeColors.textMuted }]}>ORDERBOOK</Text>
-            <View style={styles.orderbookHeader}>
-              <Text style={[styles.obHeaderText, { color: themeColors.positive }]}>YES BIDS</Text>
-              <Text style={[styles.obHeaderText, { color: themeColors.negative, textAlign: "right" }]}>
-                NO BIDS
-              </Text>
-            </View>
-            {orderbookRows.map((row, i) => (
-              <View key={i} style={styles.orderbookRow}>
-                <Text style={[styles.obQty, { color: themeColors.text }]}>{row.yQty || ""}</Text>
-                <Text style={[styles.obPrice, { color: themeColors.positive }]}>{row.yPrice || ""}</Text>
-                <Text style={[styles.obPrice, { color: themeColors.negative }]}>{row.nPrice || ""}</Text>
-                <Text style={[styles.obQty, { color: themeColors.text, textAlign: "right" }]}>
-                  {row.nQty || ""}
-                </Text>
-              </View>
-            ))}
+        {/* Liquidity spread */}
+        {market && yesPrice > 0 && (
+          <View style={styles.spreadRow}>
+            <Text style={[styles.spreadLabel, { color: themeColors.textMuted }]}>SPREAD</Text>
+            <Text style={[styles.spreadValue, { color: themeColors.text }]}>
+              {(computeLiquiditySpread(market.pricing) * 100).toFixed(1)}¢
+            </Text>
           </View>
         )}
-
-        {/* User's previous orders */}
-        <View style={[styles.ordersSection, { backgroundColor: themeColors.card }]}>
-          <Text style={[styles.sectionTitle, { color: themeColors.textMuted }]}>YOUR TRADES</Text>
-          {userOrders.length > 0 ? (
-            <View style={styles.ordersList}>
-              {userOrders.map((order) => (
-                <OrderRow key={order.pubkey} order={order} />
-              ))}
-            </View>
-          ) : (
-            <Text style={[styles.emptyText, { color: themeColors.textFaint }]}>
-              No previous trades
-            </Text>
-          )}
-        </View>
       </ScrollView>
 
       {/* Trade section — pinned to bottom */}
@@ -449,14 +410,6 @@ const styles = StyleSheet.create({
     letterSpacing: letterSpacing.wide,
   },
 
-  // Rules
-  rulesText: {
-    fontFamily: fonts.body.regular,
-    fontSize: fontSize.base,
-    lineHeight: 20,
-    marginBottom: 20,
-  },
-
   // Probability cards
   probRow: {
     flexDirection: "row",
@@ -520,55 +473,31 @@ const styles = StyleSheet.create({
     letterSpacing: letterSpacing.wide,
   },
 
-  // Orderbook
-  orderbookSection: {
-    borderRadius: 12,
-    borderCurve: "continuous",
-    padding: 12,
-    marginBottom: 16,
+  // Liquidity spread
+  spreadRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    marginBottom: 20,
   },
+  spreadLabel: {
+    fontFamily: fonts.mono.regular,
+    fontSize: fontSize.xxs,
+    letterSpacing: letterSpacing.wide,
+  },
+  spreadValue: {
+    fontFamily: fonts.mono.bold,
+    fontSize: fontSize.sm,
+    letterSpacing: letterSpacing.wide,
+  },
+
+  // Section shared
   sectionTitle: {
     fontFamily: fonts.mono.regular,
     fontSize: fontSize.xxs,
     letterSpacing: letterSpacing.wide,
     marginBottom: 8,
-  },
-  orderbookHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: 4,
-  },
-  obHeaderText: {
-    fontFamily: fonts.mono.bold,
-    fontSize: 10,
-    letterSpacing: letterSpacing.wide,
-  },
-  orderbookRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    paddingVertical: 2,
-  },
-  obQty: {
-    fontFamily: fonts.mono.regular,
-    fontSize: 11,
-    width: 60,
-  },
-  obPrice: {
-    fontFamily: fonts.mono.regular,
-    fontSize: 11,
-    width: 50,
-    textAlign: "center",
-  },
-
-  // User orders section
-  ordersSection: {
-    borderRadius: 12,
-    borderCurve: "continuous",
-    padding: 12,
-    marginBottom: 16,
-  },
-  ordersList: {
-    gap: 8,
   },
   emptyText: {
     fontFamily: fonts.mono.regular,

--- a/apps/mobile/app/market-sheet/__tests__/MarketSheet.test.tsx
+++ b/apps/mobile/app/market-sheet/__tests__/MarketSheet.test.tsx
@@ -1,5 +1,3 @@
-import { renderHook } from "@testing-library/react-native";
-import { useMemo } from "react";
 import {
   validateTradeAmount,
   parseTradeAmount,
@@ -20,20 +18,11 @@ jest.mock("@/lib/wallet-adapter", () => ({
 
 jest.mock("@/hooks/usePredictionMarket", () => ({
   usePredictionMarketDetail: jest.fn(() => ({ data: null, isLoading: false })),
-  usePredictionOrderbook: jest.fn(() => ({ data: null })),
 }));
 
 jest.mock("@/hooks/usePredictionTrading", () => ({
   useCreateOrder: jest.fn(() => ({ mutateAsync: jest.fn(), isPending: false })),
   useTradingStatus: jest.fn(() => ({ data: { trading_active: true } })),
-}));
-
-jest.mock("@/hooks/usePredictionOrders", () => ({
-  usePredictionOrders: jest.fn(() => ({ data: null })),
-}));
-
-jest.mock("@/components/predict/OrderRow", () => ({
-  OrderRow: () => null,
 }));
 
 describe("MarketSheet trade validation logic", () => {
@@ -61,29 +50,6 @@ describe("MarketSheet trade validation logic", () => {
 
   it("exports MINIMUM_TRADE_USD constant", () => {
     expect(MINIMUM_TRADE_USD).toBe(1);
-  });
-});
-
-describe("MarketSheet user orders filtering", () => {
-  it("filters orders by marketId", () => {
-    const targetMarketId = "market-123";
-    const orders = [
-      { pubkey: "a", marketId: "market-123", isYes: true, isBuy: true, contracts: "10", priceUsd: "500000", status: "filled", ownerPubkey: "owner1" },
-      { pubkey: "b", marketId: "market-456", isYes: false, isBuy: true, contracts: "5", priceUsd: "300000", status: "open", ownerPubkey: "owner1" },
-      { pubkey: "c", marketId: "market-123", isYes: false, isBuy: false, contracts: "3", priceUsd: "700000", status: "filled", ownerPubkey: "owner1" },
-    ];
-
-    const filtered = orders.filter((o) => o.marketId === targetMarketId);
-    expect(filtered).toHaveLength(2);
-    expect(filtered.every((o) => o.marketId === targetMarketId)).toBe(true);
-  });
-
-  it("returns empty array when no orders match", () => {
-    const orders = [
-      { pubkey: "a", marketId: "market-999", isYes: true, isBuy: true, contracts: "10", priceUsd: "500000", status: "filled", ownerPubkey: "owner1" },
-    ];
-    const filtered = orders.filter((o) => o.marketId === "market-123");
-    expect(filtered).toHaveLength(0);
   });
 });
 

--- a/apps/mobile/components/feed/PredictionCard.tsx
+++ b/apps/mobile/components/feed/PredictionCard.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "@/lib/store";
 import { colors } from "@/constants/theme";
 import { fonts, fontSize, letterSpacing } from "@/constants/typography";
 import { useLiveMarketPrice } from "@/hooks/useLiveMarketPrice";
+import { formatCompactVolume, formatCompactDate } from "@mintfeed/shared";
 import type { PredictionMarket } from "@mintfeed/shared";
 
 interface PredictionCardProps {
@@ -41,10 +42,16 @@ export const PredictionCard = memo(function PredictionCard({
   const yesPrice = prices["Yes"] ?? 0;
   const noPrice = prices["No"] ?? 0;
   const yesPercent = Math.round(yesPrice * 100);
-  const noPercent = Math.round(noPrice * 100);
   const hasOdds = yesPrice > 0 || noPrice > 0;
   const isResolved = yesPrice >= 0.99 || noPrice >= 0.99;
   const winnerSide = yesPrice >= 0.99 ? "YES" : "NO";
+
+  const parts: string[] = [];
+  const dateStr = formatCompactDate(market.endDate);
+  if (dateStr) parts.push(dateStr);
+  const volStr = formatCompactVolume(market.volume ?? 0);
+  if (volStr) parts.push(volStr);
+  const metaText = parts.join(" \u00B7 ") || null;
 
   if (isResolved) {
     return (
@@ -73,7 +80,7 @@ export const PredictionCard = memo(function PredictionCard({
             <Text style={[styles.resolvedBadge, { color: themeColors.textMuted, backgroundColor: themeColors.trackBg }]}>
               RESOLVED
             </Text>
-            <Text style={[styles.sideText, { color: themeColors.textSecondary }]}>
+            <Text style={[styles.percentText, { color: themeColors.textSecondary }]}>
               {winnerSide} won
             </Text>
           </View>
@@ -81,6 +88,8 @@ export const PredictionCard = memo(function PredictionCard({
       </View>
     );
   }
+
+  const accessLabel = `${market.question}, ${yesPercent} percent chance${dateStr ? `, resolves ${dateStr}` : ""}`;
 
   return (
     <Pressable
@@ -97,7 +106,7 @@ export const PredictionCard = memo(function PredictionCard({
         params: { question: market.question },
       })}
       accessibilityRole="button"
-      accessibilityLabel={`${market.question}, Yes at ${yesPercent} percent, No at ${noPercent} percent`}
+      accessibilityLabel={accessLabel}
       accessibilityHint="Opens prediction market details"
     >
       {/* Mint accent stripe */}
@@ -114,11 +123,11 @@ export const PredictionCard = memo(function PredictionCard({
           {market.question}
         </Text>
 
-        {/* YES price | bar | NO price */}
+        {/* Probability % | bar | meta (date · volume) */}
         {hasOdds && (
           <View style={styles.oddsRow}>
-            <Text style={[styles.sideText, { color: themeColors.positive }]}>
-              YES {yesPercent}¢
+            <Text style={[styles.percentText, { color: themeColors.positive }]}>
+              {yesPercent}%
             </Text>
             <View style={[styles.barTrack, { backgroundColor: themeColors.trackBg }]}>
               <View
@@ -130,19 +139,13 @@ export const PredictionCard = memo(function PredictionCard({
                   },
                 ]}
               />
-              <View
-                style={[
-                  styles.barNo,
-                  {
-                    flex: noPercent || 1,
-                    backgroundColor: themeColors.negative,
-                  },
-                ]}
-              />
+              <View style={{ flex: (100 - yesPercent) || 1 }} />
             </View>
-            <Text style={[styles.sideText, { color: themeColors.negative, textAlign: "right" }]}>
-              NO {noPercent}¢
-            </Text>
+            {metaText && (
+              <Text style={[styles.metaText, { color: themeColors.textMuted }]}>
+                {metaText}
+              </Text>
+            )}
           </View>
         )}
       </View>
@@ -180,11 +183,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
-  sideText: {
+  percentText: {
     fontFamily: fonts.mono.bold,
     fontSize: 10,
     letterSpacing: letterSpacing.wide,
-    minWidth: 46,
+    minWidth: 30,
   },
   barTrack: {
     flex: 1,
@@ -192,15 +195,16 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     overflow: "hidden",
     flexDirection: "row",
-    gap: 1,
   },
   barYes: {
     height: "100%",
     borderRadius: 2,
   },
-  barNo: {
-    height: "100%",
-    borderRadius: 2,
+  metaText: {
+    fontFamily: fonts.mono.regular,
+    fontSize: 9,
+    letterSpacing: letterSpacing.wide,
+    textAlign: "right",
   },
   resolvedBadge: {
     fontFamily: fonts.mono.bold,

--- a/packages/shared/src/trade-validation.test.ts
+++ b/packages/shared/src/trade-validation.test.ts
@@ -4,6 +4,9 @@ import {
   parseTradeAmount,
   isBinaryMarket,
   formatResolutionCountdown,
+  formatCompactVolume,
+  formatCompactDate,
+  computeLiquiditySpread,
 } from "./trade-validation";
 
 describe("validateTradeAmount", () => {
@@ -61,6 +64,41 @@ describe("isBinaryMarket", () => {
     expect(isBinaryMarket(undefined)).toBe(false);
     expect(isBinaryMarket("Yes")).toBe(false);
   });
+
+  it("returns false for multi-outcome markets", () => {
+    expect(isBinaryMarket(["Trump", "Biden", "DeSantis"])).toBe(false);
+    expect(isBinaryMarket(["Option A", "Option B"])).toBe(false);
+  });
+});
+
+describe("filterBinaryMarkets", () => {
+  it("keeps only markets with Yes/No outcomes", () => {
+    const markets = [
+      { id: "1", outcomes: ["Yes", "No"], question: "Binary?" },
+      { id: "2", outcomes: ["Trump", "Biden", "DeSantis"], question: "Who wins?" },
+      { id: "3", outcomes: ["Yes", "No"], question: "Another binary?" },
+    ];
+    const filtered = markets.filter((m) => isBinaryMarket(m.outcomes));
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((m) => m.id)).toEqual(["1", "3"]);
+  });
+
+  it("returns empty array when no binary markets exist", () => {
+    const markets = [
+      { id: "1", outcomes: ["A", "B", "C"], question: "Multi?" },
+      { id: "2", outcomes: null, question: "Null outcomes?" },
+    ];
+    const filtered = markets.filter((m) => isBinaryMarket(m.outcomes));
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("handles outcomePrices-only check as fallback", () => {
+    const prices = { Yes: 0.73, No: 0.27 };
+    const nonBinaryPrices = { Trump: 0.5, Biden: 0.3, DeSantis: 0.2 };
+    const hasYesNo = (op: Record<string, number>) => "Yes" in op && "No" in op && Object.keys(op).length === 2;
+    expect(hasYesNo(prices)).toBe(true);
+    expect(hasYesNo(nonBinaryPrices)).toBe(false);
+  });
 });
 
 describe("formatResolutionCountdown", () => {
@@ -102,4 +140,31 @@ describe("formatResolutionCountdown", () => {
     const pastTime = Math.floor(Date.now() / 1000) - 3600;
     expect(formatResolutionCountdown(pastTime)).toBe("Resolved");
   });
+});
+
+describe("formatCompactVolume", () => {
+  it("formats millions", () => expect(formatCompactVolume(362_000_000_000_000)).toBe("$362M"));
+  it("formats thousands", () => expect(formatCompactVolume(50_000_000_000)).toBe("$50K"));
+  it("formats small amounts", () => expect(formatCompactVolume(50_000_000)).toBe("$50"));
+  it("returns null for zero", () => expect(formatCompactVolume(0)).toBeNull());
+});
+
+describe("formatCompactDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-08T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats same-year date without year", () => expect(formatCompactDate("2026-12-31T00:00:00Z")).toBe("Dec 31"));
+  it("formats different-year date with year", () => expect(formatCompactDate("2027-06-15T00:00:00Z")).toBe("Jun 15, 2027"));
+  it("returns null for null input", () => expect(formatCompactDate(null)).toBeNull());
+});
+
+describe("computeLiquiditySpread", () => {
+  it("computes spread in USD", () => expect(computeLiquiditySpread({ buyYesPriceUsd: 730_000, sellYesPriceUsd: 750_000 })).toBeCloseTo(0.02));
+  it("returns 0 for zero prices", () => expect(computeLiquiditySpread({ buyYesPriceUsd: 0, sellYesPriceUsd: 0 })).toBe(0));
 });

--- a/packages/shared/src/trade-validation.ts
+++ b/packages/shared/src/trade-validation.ts
@@ -1,4 +1,5 @@
 import { MINIMUM_TRADE_USD } from "./constants";
+import { MICRO_USD } from "./types";
 
 type ValidationError = "BELOW_MINIMUM" | "INVALID_NUMBER";
 
@@ -43,4 +44,29 @@ export function formatResolutionCountdown(closeTimeUnix: number): string {
   if (hours > 0) return `Resolves in ${hours} ${hours === 1 ? "hour" : "hours"}`;
   if (minutes > 0) return `Resolves in ${minutes} min`;
   return "Resolves today";
+}
+
+export function formatCompactVolume(volumeMicroUsd: number): string | null {
+  if (!volumeMicroUsd || volumeMicroUsd <= 0) return null;
+  const usd = volumeMicroUsd / MICRO_USD;
+  if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (usd >= 1_000) return `$${(usd / 1_000).toFixed(0)}K`;
+  return `$${usd.toFixed(0)}`;
+}
+
+export function formatCompactDate(isoDate: string | null | undefined): string | null {
+  if (!isoDate) return null;
+  const date = new Date(isoDate);
+  if (isNaN(date.getTime())) return null;
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
+export function computeLiquiditySpread(pricing: { buyYesPriceUsd: number; sellYesPriceUsd: number }): number {
+  if (pricing.buyYesPriceUsd === 0 && pricing.sellYesPriceUsd === 0) return 0;
+  return (pricing.sellYesPriceUsd - pricing.buyYesPriceUsd) / MICRO_USD;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -41,6 +41,8 @@ export interface PredictionMarket {
   question: string;     // Event title
   outcomePrices: Record<string, number>;  // { "Yes": 0.73, "No": 0.27 }
   marketUrl: string;    // Jupiter prediction page URL
+  endDate?: string | null;   // ISO 8601 datetime
+  volume?: number;           // micro-USD from Jupiter
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
## Summary
- Filter non-binary markets at API layer using `isBinaryMarket()` in feed routes
- Replace cents pricing with percentage format, simplify PredictionCard and MarketSheet UI
- Add shared utilities (formatCompactVolume, formatCompactDate, computeLiquiditySpread)

## Test plan
- `pnpm --filter shared test` — 27 tests pass (including new binary filter + utility tests)
- `pnpm lint` — TypeScript checks pass across all 4 packages
- Verified on Android device: feed cards show %, market sheet shows simplified layout, no orderbook/trades

🤖 Generated with [Claude Code](https://claude.com/claude-code)