### PR TITLE
fix: limit prediction markets to 2 per card

### DIFF
--- a/apps/mobile/components/feed/NewsCard.tsx
+++ b/apps/mobile/components/feed/NewsCard.tsx
@@ -104,7 +104,7 @@ interface NewsCardProps {
   walletConnected: boolean;
 }
 
-const MAX_VISIBLE_MARKETS = 3;
+const MAX_VISIBLE_MARKETS = 2; // Limit to 2 relevant markets per card for cleaner UX
 
 export const NewsCard = memo(function NewsCard({ article, onSwipeBet, walletConnected }: NewsCardProps) {
   const { height: screenHeight } = useWindowDimensions();


### PR DESCRIPTION
## Problem
News cards were displaying up to 3 prediction markets, creating visual clutter and making cards harder to scan quickly.

## Solution
Reduced `MAX_VISIBLE_MARKETS` constant from 3 to 2. Users still see the most relevant markets matched to each article, but with less visual noise.

## Changes
- `apps/mobile/components/feed/NewsCard.tsx`: Changed constant from 3 → 2

## Impact
- ✓ Cleaner, more focused card design
- ✓ Faster scanning and comprehension
- ✓ No functional regression (market slice still works the same way)

## Testing
- Visual verification: Open app, view feed, confirm max 2 markets per card

Addresses feature-reference.md item #4