### PR TITLE
fix: update quick bets preset amounts and enforce minimum

### DIFF
--- a/apps/mobile/hooks/useSwipeBet.ts
+++ b/apps/mobile/hooks/useSwipeBet.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useMobileWallet } from "@wallet-ui/react-native-web3js";
-import { useAppStore } from "@/lib/store";
+import { useAppStore, QUICK_BET_MIN } from "@/lib/store";
 import { useCreateOrder } from "@/hooks/usePredictionTrading";
 import { usdToMicro, USDC_MINT } from "@mintfeed/shared";
 import { showToast } from "@/lib/toast";
@@ -33,6 +33,12 @@ export function useSwipeBet() {
   const executeBet = useCallback(
     async (marketId: string, side: "yes" | "no", amount: number) => {
       if (!walletAddress) return;
+
+      // Validate minimum bet amount
+      if (amount < QUICK_BET_MIN) {
+        showToast("error", "Bet Too Small", `Minimum bet is $${QUICK_BET_MIN}`);
+        return;
+      }
 
       try {
         await createOrder.mutateAsync({

--- a/apps/mobile/lib/store.ts
+++ b/apps/mobile/lib/store.ts
@@ -3,7 +3,8 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { ThemeMode } from "@/constants/theme";
 
-export const QUICK_BET_OPTIONS = [1, 2, 5, 10, 25] as const;
+export const QUICK_BET_OPTIONS = [5, 10, 25, 50] as const;
+export const QUICK_BET_MIN = 5;
 export type QuickBetAmount = (typeof QUICK_BET_OPTIONS)[number];
 
 interface AppState {


### PR DESCRIPTION
## Problem
Quick bet presets were [1, 2, 5, 10, 25] — too granular, including low amounts that don't make sense for prediction markets. Need to focus on meaningful bet sizes and enforce a minimum.

## Solution

### Changes
1. **Updated preset amounts**: [1, 2, 5, 10, 25] → [5, 10, 25, 50]
   - Removes frivolous $1 and $2 options
   - Adds $50 option for larger positions

2. **Added QUICK_BET_MIN constant**: `5` (exported from store)
   - Enforces minimum bet amount across the app
   - Centralized, easy to update

3. **Runtime validation in executeBet**:
   - Checks amount >= QUICK_BET_MIN before submitting
   - Shows user-friendly toast: "Minimum bet is $5"
   - Prevents accidental micro-bets

### Impact
- Cleaner UI: 4 preset buttons instead of 5
- Better UX: meaningful bet sizes
- Safe: enforced minimum prevents mistakes
- Flexible: users can still enter custom amounts (with validation)

## Testing
- Tap each preset button: confirms amounts [5, 10, 25, 50]
- Try entering < 5 in custom input: shows validation error
- Try swiping to bet with custom amount < 5: shows error toast

Addresses feature-reference.md item #6