### PR TITLE
fix: restore Railway builds by fixing Dockerfile patches + lockfile hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY apps/api/package.json ./apps/api/
 COPY packages/db/package.json ./packages/db/
 COPY packages/shared/package.json ./packages/shared/
 
+# Copy patches (referenced by pnpm-lock.yaml)
+COPY patches/ ./patches/
+
 # Copy Prisma schema (needed for generate during install)
 COPY packages/db/prisma ./packages/db/prisma/
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@wallet-ui/react-native-web3js@4.0.1':
-    hash: em4jhh3glyclnk3wmlyl3dpj3e
+    hash: 423fyzrf6ef7pt2bnzr32iifq4
     path: patches/@wallet-ui__react-native-web3js@4.0.1.patch
 
 importers:
@@ -15,13 +15,13 @@ importers:
     dependencies:
       expo:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react:
         specifier: 19.2.0
         version: 19.2.0
       react-native:
         specifier: 0.83.2
-        version: 0.83.2(@babel/core@7.29.0)(react@19.2.0)
+        version: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     devDependencies:
       turbo:
         specifier: ^2.3.0
@@ -46,13 +46,13 @@ importers:
         version: link:../../packages/shared
       '@onsol/tldparser':
         specifier: ^1.2.1
-        version: 1.2.1(@solana/web3.js@1.98.4)(bn.js@5.2.3)(borsh@2.0.0)(buffer@6.0.1)(typescript@5.9.3)
+        version: 1.2.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bn.js@5.2.3)(borsh@2.0.0)(buffer@6.0.3)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@prisma/client':
         specifier: ^6.2.0
-        version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
       '@solana/web3.js':
         specifier: ^1.98.4
-        version: 1.98.4(typescript@5.9.3)
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-server-sdk:
         specifier: ^6.1.0
         version: 6.1.0
@@ -80,7 +80,7 @@ importers:
         version: 3.0.11
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -89,7 +89,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/mobile:
     dependencies:
@@ -107,67 +107,67 @@ importers:
         version: 0.4.1
       '@expo/metro-runtime':
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@expo/vector-icons':
         specifier: ^15.1.1
-        version: 15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@mintfeed/shared':
         specifier: workspace:*
         version: link:../../packages/shared
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
-        version: 2.2.0(react-native@0.83.2)
+        version: 2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
       '@shopify/flash-list':
         specifier: ^2.3.1
-        version: 2.3.1(@babel/runtime@7.29.2)(react-native@0.83.2)(react@19.2.0)
+        version: 2.3.1(@babel/runtime@7.29.2)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@solana/web3.js':
         specifier: ^1.98.4
-        version: 1.98.4(typescript@5.9.3)
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.91.3(react@19.2.0)
       '@wallet-ui/react-native-web3js':
         specifier: ^4.0.1
-        version: 4.0.1(patch_hash=em4jhh3glyclnk3wmlyl3dpj3e)(@solana/kit@6.5.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 4.0.1(patch_hash=423fyzrf6ef7pt2bnzr32iifq4)(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
       expo:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-apple-authentication:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
       expo-application:
         specifier: 55.0.0-canary-20260223-05214f1
         version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)
       expo-blur:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-crypto:
         specifier: 55.0.0-canary-20260223-05214f1
         version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)
       expo-font:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-haptics:
         specifier: 55.0.0-canary-20260223-05214f1
         version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)
       expo-image:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-linear-gradient:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-linking:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-notifications:
         specifier: 55.0.15-canary-20260328-2049187
-        version: 55.0.15-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 55.0.15-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-router:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(@expo/log-box@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(@testing-library/react-native@12.9.0)(@types/react@19.2.14)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-linking@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-gesture-handler@2.30.0)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(uyyophz2gdrjkjaoq6emi2a5pa)
       expo-secure-store:
         specifier: 55.0.0-canary-20260223-05214f1
         version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)
@@ -176,10 +176,10 @@ importers:
         version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
       expo-status-bar:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)
+        version: 55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-web-browser:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)
+        version: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
       fast-text-encoding:
         specifier: ^1.0.6
         version: 1.0.6
@@ -194,47 +194,47 @@ importers:
         version: 19.2.0(react@19.2.0)
       react-native:
         specifier: 0.83.2
-        version: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+        version: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       react-native-gesture-handler:
         specifier: ~2.30.0
-        version: 2.30.0(react-native@0.83.2)(react@19.2.0)
+        version: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-get-random-values:
         specifier: ^1.11.0
-        version: 1.11.0(react-native@0.83.2)
+        version: 1.11.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
       react-native-pager-view:
         specifier: 8.0.0
-        version: 8.0.0(react-native@0.83.2)(react@19.2.0)
+        version: 8.0.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-passkeys:
         specifier: ^0.4.0
-        version: 0.4.0(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+        version: 0.4.0(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: ~4.2.2
-        version: 4.2.3(react-native-worklets@0.7.2)(react-native@0.83.2)(react@19.2.0)
+        version: 4.2.3(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-safe-area-context:
         specifier: 5.6.2
-        version: 5.6.2(react-native@0.83.2)(react@19.2.0)
+        version: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-screens:
         specifier: ~4.23.0
-        version: 4.23.0(react-native@0.83.2)(react@19.2.0)
+        version: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-svg:
         specifier: ^15.15.3
-        version: 15.15.4(react-native@0.83.2)(react@19.2.0)
+        version: 15.15.4(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-webview:
         specifier: 13.16.0
-        version: 13.16.0(react-native@0.83.2)(react@19.2.0)
+        version: 13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react-native-worklets:
         specifier: 0.7.2
-        version: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2)(react@19.2.0)
+        version: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       zustand:
         specifier: ^5.0.0
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0)
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@babel/runtime':
         specifier: ^7.28.6
         version: 7.29.2
       '@testing-library/react-native':
         specifier: ^12.0.0
-        version: 12.9.0(jest@29.7.0)(react-native@0.83.2)(react-test-renderer@19.2.4)(react@19.2.0)
+        version: 12.9.0(jest@29.7.0(@types/node@22.19.15))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react-test-renderer@19.2.4(react@19.2.0))(react@19.2.0)
       '@types/jest':
         specifier: ^29.0.0
         version: 29.5.14
@@ -243,10 +243,10 @@ importers:
         version: 19.2.14
       jest:
         specifier: ^29.0.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@22.19.15)
       jest-expo:
         specifier: 55.0.0-canary-20260223-05214f1
-        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(expo@55.0.0-canary-20260223-05214f1)(jest@29.7.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+        version: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.0-canary-20260223-05214f1)(jest@29.7.0(@types/node@22.19.15))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -255,22 +255,22 @@ importers:
     dependencies:
       '@phosphor-icons/react':
         specifier: ^2.1.0
-        version: 2.1.10(react-dom@19.2.0)(react@19.2.0)
+        version: 2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-three/drei':
         specifier: ^10.7.7
-        version: 10.7.7(@react-three/fiber@9.5.0)(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.0)(react@19.2.0)(three@0.183.2)
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(three@0.183.2))(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(three@0.183.2)
       '@react-three/fiber':
         specifier: ^9.5.0
-        version: 9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(three@0.183.2)
+        version: 9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(three@0.183.2)
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
       lottie-react:
         specifier: ^2.4.1
-        version: 2.4.1(react-dom@19.2.0)(react@19.2.0)
+        version: 2.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: ^15.1.0
-        version: 15.5.14(@babel/core@7.29.0)(react-dom@19.2.0)(react@19.2.0)
+        version: 15.5.14(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.0.0
         version: 19.2.0
@@ -301,7 +301,7 @@ importers:
         version: 8.5.8
       tailwindcss:
         specifier: ^3.4.0
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -310,7 +310,7 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: ^6.2.0
-        version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       prisma:
         specifier: ^6.2.0
@@ -333,7 +333,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -3416,9 +3416,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@6.0.1:
-    resolution: {integrity: sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -7552,7 +7549,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.27': {}
 
-  '@expo/cli@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)':
+  '@expo/cli@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
@@ -7561,20 +7558,20 @@ snapshots:
       '@expo/env': 2.1.2-canary-20260223-05214f1
       '@expo/image-utils': 0.8.13-canary-20260223-05214f1
       '@expo/json-file': 10.0.13-canary-20260223-05214f1
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/metro': 54.2.0
-      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
+      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)
+      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(bufferutil@4.1.0)(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
       '@expo/osascript': 2.4.3-canary-20260223-05214f1
       '@expo/package-manager': 1.10.4-canary-20260223-05214f1
       '@expo/plist': 0.5.3-canary-20260223-05214f1
       '@expo/prebuild-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
       '@expo/require-utils': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/router-server': 55.0.0-canary-20260223-05214f1(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react@19.2.0)
+      '@expo/router-server': 55.0.0-canary-20260223-05214f1(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@expo/schema-utils': 55.0.0-canary-20260223-05214f1
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.4.1
-      '@react-native/dev-middleware': 0.83.2
+      '@react-native/dev-middleware': 0.83.2(bufferutil@4.1.0)
       accepts: 1.3.8
       arg: 5.0.2
       better-opn: 3.0.2
@@ -7586,8 +7583,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-router: 55.0.0-canary-20260223-05214f1(@expo/log-box@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(@testing-library/react-native@12.9.0)(@types/react@19.2.14)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-linking@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-gesture-handler@2.30.0)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-server: 55.0.0-canary-20260223-05214f1
       fetch-nodeshim: 0.4.9
       getenv: 2.0.0
@@ -7601,7 +7597,6 @@ snapshots:
       pretty-format: 29.7.0
       progress: 2.0.3
       prompts: 2.4.2
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       resolve-from: 5.0.0
       semver: 7.7.4
       send: 0.19.2
@@ -7614,80 +7609,9 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@expo/cli@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/config-plugins': 55.0.0-canary-20260223-05214f1
-      '@expo/devcert': 1.2.1
-      '@expo/env': 2.1.2-canary-20260223-05214f1
-      '@expo/image-utils': 0.8.13-canary-20260223-05214f1
-      '@expo/json-file': 10.0.13-canary-20260223-05214f1
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/metro': 54.2.0
-      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
-      '@expo/osascript': 2.4.3-canary-20260223-05214f1
-      '@expo/package-manager': 1.10.4-canary-20260223-05214f1
-      '@expo/plist': 0.5.3-canary-20260223-05214f1
-      '@expo/prebuild-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
-      '@expo/require-utils': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/router-server': 55.0.0-canary-20260223-05214f1(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react@19.2.0)
-      '@expo/schema-utils': 55.0.0-canary-20260223-05214f1
-      '@expo/spawn-async': 1.7.2
-      '@expo/ws-tunnel': 1.0.6
-      '@expo/xcpretty': 4.4.1
-      '@react-native/dev-middleware': 0.83.2
-      accepts: 1.3.8
-      arg: 5.0.2
-      better-opn: 3.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1
-      connect: 3.7.0
-      debug: 4.4.3
-      dnssd-advertise: 1.1.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-server: 55.0.0-canary-20260223-05214f1
-      fetch-nodeshim: 0.4.9
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.0
-      multitars: 0.2.4
-      node-forge: 1.3.3
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.3
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      react-native: 0.83.2(@babel/core@7.29.0)(react@19.2.0)
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      send: 0.19.2
-      slugify: 1.6.8
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      zod: 3.25.76
+    optionalDependencies:
+      expo-router: 55.0.0-canary-20260223-05214f1(uyyophz2gdrjkjaoq6emi2a5pa)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -7786,17 +7710,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)':
+  '@expo/devtools@55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
       chalk: 4.1.2
+    optionalDependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  '@expo/dom-webview@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)':
+  '@expo/dom-webview@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   '@expo/env@2.1.2-canary-20260223-05214f1':
     dependencies:
@@ -7868,16 +7793,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)':
+  '@expo/log-box@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@expo/dom-webview': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      '@expo/dom-webview': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       anser: 1.4.10
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       stacktrace-parser: 0.1.11
 
-  '@expo/metro-config@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)':
+  '@expo/metro-config@55.0.0-canary-20260223-05214f1(bufferutil@4.1.0)(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -7885,12 +7810,11 @@ snapshots:
       '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
       '@expo/env': 2.1.2-canary-20260223-05214f1
       '@expo/json-file': 10.0.13-canary-20260223-05214f1
-      '@expo/metro': 54.2.0
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)
       '@expo/spawn-async': 1.7.2
       browserslist: 4.28.1
       chalk: 4.1.2
       debug: 4.4.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
       getenv: 2.0.0
       glob: 13.0.6
       hermes-parser: 0.29.1
@@ -7899,33 +7823,36 @@ snapshots:
       picomatch: 4.0.3
       postcss: 8.4.49
       resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-runtime@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)':
+  '@expo/metro-runtime@55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       anser: 1.4.10
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
 
-  '@expo/metro@54.2.0':
+  '@expo/metro@54.2.0(bufferutil@4.1.0)':
     dependencies:
-      metro: 0.83.3
+      metro: 0.83.3(bufferutil@4.1.0)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-minify-terser: 0.83.3
@@ -7934,7 +7861,7 @@ snapshots:
       metro-source-map: 0.83.3
       metro-symbolicate: 0.83.3
       metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
+      metro-transform-worker: 0.83.3(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7974,7 +7901,7 @@ snapshots:
       '@expo/json-file': 10.0.13-canary-20260223-05214f1
       '@react-native/normalize-colors': 0.83.2
       debug: 4.4.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -7985,6 +7912,7 @@ snapshots:
   '@expo/require-utils@55.0.0-canary-20260223-05214f1(typescript@5.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.0
+    optionalDependencies:
       typescript: 5.9.3
 
   '@expo/require-utils@55.0.4-canary-20260328-2049187(typescript@5.9.3)':
@@ -7992,32 +7920,23 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.0-canary-20260223-05214f1(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react@19.2.0)':
+  '@expo/router-server@55.0.0-canary-20260223-05214f1(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)
       debug: 4.4.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      expo-router: 55.0.0-canary-20260223-05214f1(@expo/log-box@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(@testing-library/react-native@12.9.0)(@types/react@19.2.14)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-linking@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-gesture-handler@2.30.0)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
+      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-server: 55.0.0-canary-20260223-05214f1
       react: 19.2.0
+    optionalDependencies:
+      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      expo-router: 55.0.0-canary-20260223-05214f1(uyyophz2gdrjkjaoq6emi2a5pa)
       react-dom: 19.2.0(react@19.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/router-server@55.0.0-canary-20260223-05214f1(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-server@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react@19.2.0)':
-    dependencies:
-      debug: 4.4.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      expo-server: 55.0.0-canary-20260223-05214f1
-      react: 19.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8031,11 +7950,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)':
+  '@expo/vector-icons@15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -8427,10 +8346,10 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@metaplex-foundation/beet-solana@0.4.1(typescript@5.9.3)':
+  '@metaplex-foundation/beet-solana@0.4.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@metaplex-foundation/beet': 0.7.2
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       bs58: 5.0.0
       debug: 4.4.3
     transitivePeerDependencies:
@@ -8513,16 +8432,16 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@onsol/tldparser@1.2.1(@solana/web3.js@1.98.4)(bn.js@5.2.3)(borsh@2.0.0)(buffer@6.0.1)(typescript@5.9.3)':
+  '@onsol/tldparser@1.2.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bn.js@5.2.3)(borsh@2.0.0)(buffer@6.0.3)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@ethersproject/sha2': 5.8.0
-      '@metaplex-foundation/beet-solana': 0.4.1(typescript@5.9.3)
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
+      '@metaplex-foundation/beet-solana': 0.4.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       async: 3.2.6
       bn.js: 5.2.3
       borsh: 2.0.0
-      buffer: 6.0.1
-      ethers: 6.16.0
+      buffer: 6.0.3
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -8530,13 +8449,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@phosphor-icons/react@2.1.10(react-dom@19.2.0)(react@19.2.0)':
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@prisma/client@6.19.2(prisma@6.19.2)(typescript@5.9.3)':
-    dependencies:
+  '@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
       prisma: 6.19.2(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -8572,179 +8491,209 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-collection@1.1.7(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-dialog@1.1.15(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       aria-hidden: 1.2.6
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
-
-  '@radix-ui/react-portal@1.1.9(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-slot@1.2.0(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-tabs@1.1.13(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.0)':
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.83.2)':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   '@react-native/assets-registry@0.83.2': {}
 
@@ -8816,13 +8765,13 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.83.2':
+  '@react-native/community-cli-plugin@0.83.2(bufferutil@4.1.0)':
     dependencies:
-      '@react-native/dev-middleware': 0.83.2
+      '@react-native/dev-middleware': 0.83.2(bufferutil@4.1.0)
       debug: 4.4.3
       invariant: 2.2.4
-      metro: 0.83.5
-      metro-config: 0.83.5
+      metro: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -8837,7 +8786,7 @@ snapshots:
       cross-spawn: 7.0.6
       fb-dotslash: 0.5.8
 
-  '@react-native/dev-middleware@0.83.2':
+  '@react-native/dev-middleware@0.83.2(bufferutil@4.1.0)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.83.2
@@ -8850,7 +8799,7 @@ snapshots:
       nullthrows: 1.1.1
       open: 7.4.2
       serve-static: 1.16.3
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8862,30 +8811,24 @@ snapshots:
 
   '@react-native/normalize-colors@0.83.2': {}
 
-  '@react-native/virtualized-lists@0.83.2(@types/react@19.2.14)(react-native@0.83.2)(react@19.2.0)':
+  '@react-native/virtualized-lists@0.83.2(@types/react@19.2.14)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+    optionalDependencies:
       '@types/react': 19.2.14
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  '@react-native/virtualized-lists@0.83.2(react-native@0.83.2)(react@19.2.0)':
+  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(react@19.2.0)
-
-  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)':
-    dependencies:
-      '@react-navigation/elements': 2.9.11(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native@0.83.2)(react@19.2.0)
-      '@react-navigation/native': 7.1.28(react-native@0.83.2)(react@19.2.0)
+      '@react-navigation/elements': 2.9.11(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       color: 4.2.3
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.2)(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -8902,50 +8845,50 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  '@react-navigation/elements@2.9.11(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native@0.83.2)(react@19.2.0)':
+  '@react-navigation/elements@2.9.11(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@react-navigation/native': 7.1.28(react-native@0.83.2)(react@19.2.0)
+      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       color: 4.2.3
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       use-latest-callback: 0.2.6(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  '@react-navigation/native-stack@7.10.1(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)':
+  '@react-navigation/native-stack@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@react-navigation/elements': 2.9.11(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native@0.83.2)(react@19.2.0)
-      '@react-navigation/native': 7.1.28(react-native@0.83.2)(react@19.2.0)
+      '@react-navigation/elements': 2.9.11(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       color: 4.2.3
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.2)(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.1.28(react-native@0.83.2)(react@19.2.0)':
+  '@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@react-navigation/core': 7.16.2(react@19.2.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       use-latest-callback: 0.2.6(react@19.2.0)
 
   '@react-navigation/routers@7.5.3':
     dependencies:
       nanoid: 3.3.11
 
-  '@react-three/drei@10.7.7(@react-three/fiber@9.5.0)(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.0)(react@19.2.0)(three@0.183.2)':
+  '@react-three/drei@10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(three@0.183.2))(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(three@0.183.2)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mediapipe/tasks-vision': 0.10.17
       '@monogrid/gainmap-js': 3.4.0(three@0.183.2)
-      '@react-three/fiber': 9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(three@0.183.2)
+      '@react-three/fiber': 9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(three@0.183.2)
       '@use-gesture/react': 10.3.1(react@19.2.0)
       camera-controls: 3.1.2(three@0.183.2)
       cross-env: 7.0.3
@@ -8955,7 +8898,6 @@ snapshots:
       maath: 0.10.8(@types/three@0.183.1)(three@0.183.2)
       meshline: 3.3.1(three@0.183.2)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
       stats-gl: 2.4.2(@types/three@0.183.1)(three@0.183.2)
       stats.js: 0.17.0
       suspend-react: 0.1.3(react@19.2.0)
@@ -8966,29 +8908,32 @@ snapshots:
       tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
       utility-types: 3.11.0
-      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0)
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+    optionalDependencies:
+      react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/three'
       - immer
 
-  '@react-three/fiber@9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(three@0.183.2)':
+  '@react-three/fiber@9.5.0(@types/react@19.2.14)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(three@0.183.2)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@types/webxr': 0.5.24
       base64-js: 1.5.1
       buffer: 6.0.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
       its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-native: 0.83.2(@babel/core@7.29.0)(react@19.2.0)
-      react-use-measure: 2.1.7(react-dom@19.2.0)(react@19.2.0)
+      react-use-measure: 2.1.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       scheduler: 0.27.0
       suspend-react: 0.1.3(react@19.2.0)
       three: 0.183.2
       use-sync-external-store: 1.6.0(react@19.2.0)
-      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0)
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+    optionalDependencies:
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-dom: 19.2.0(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -9068,11 +9013,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.1':
     optional: true
 
-  '@shopify/flash-list@2.3.1(@babel/runtime@7.29.2)(react-native@0.83.2)(react@19.2.0)':
+  '@shopify/flash-list@2.3.1(@babel/runtime@7.29.2)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -9084,10 +9029,10 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.6(@solana/web3.js@1.98.4)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2)(typescript@5.9.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2)(typescript@5.9.3)
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       bs58: 6.0.0
       js-base64: 3.7.8
     transitivePeerDependencies:
@@ -9095,14 +9040,14 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2)(typescript@5.9.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol@2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
       js-base64: 3.7.8
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -9115,6 +9060,7 @@ snapshots:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9137,6 +9083,7 @@ snapshots:
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9149,6 +9096,7 @@ snapshots:
   '@solana/assertions@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/buffer-layout@4.0.1':
@@ -9173,6 +9121,7 @@ snapshots:
   '@solana/codecs-core@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/codecs-data-structures@3.0.3(typescript@5.9.3)':
@@ -9187,6 +9136,7 @@ snapshots:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
@@ -9211,6 +9161,7 @@ snapshots:
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/codecs-strings@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9234,6 +9185,7 @@ snapshots:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
@@ -9244,6 +9196,7 @@ snapshots:
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/options': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9270,10 +9223,11 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/fast-stable-stringify@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/functional@3.0.3(typescript@5.9.3)':
@@ -9281,7 +9235,7 @@ snapshots:
       typescript: 5.9.3
 
   '@solana/functional@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/instruction-plans@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9292,6 +9246,7 @@ snapshots:
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9306,6 +9261,7 @@ snapshots:
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/keys@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9326,11 +9282,12 @@ snapshots:
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/accounts': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -9349,13 +9306,14 @@ snapshots:
       '@solana/rpc-api': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
@@ -9367,7 +9325,7 @@ snapshots:
       typescript: 5.9.3
 
   '@solana/nominal-types@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/offchain-messages@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9380,6 +9338,7 @@ snapshots:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/keys': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9391,12 +9350,13 @@ snapshots:
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
   '@solana/plugin-core@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/plugin-interfaces@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9408,6 +9368,7 @@ snapshots:
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9423,6 +9384,7 @@ snapshots:
       '@solana/plugin-interfaces': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-api': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9431,6 +9393,7 @@ snapshots:
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9440,7 +9403,7 @@ snapshots:
       typescript: 5.9.3
 
   '@solana/promises@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/react@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)':
@@ -9474,22 +9437,24 @@ snapshots:
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
   '@solana/rpc-parsed-types@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/rpc-spec-types@6.5.0(typescript@5.9.3)':
-    dependencies:
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/rpc-spec@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/rpc-subscriptions-api@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9501,18 +9466,20 @@ snapshots:
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@6.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.5.0(bufferutil@4.1.0)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/functional': 6.5.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9523,9 +9490,10 @@ snapshots:
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-subscriptions@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 6.5.0(typescript@5.9.3)
@@ -9533,11 +9501,12 @@ snapshots:
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.5.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.5.0(bufferutil@4.1.0)(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-transformers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
@@ -9551,6 +9520,7 @@ snapshots:
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9560,8 +9530,9 @@ snapshots:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
       undici-types: 7.24.5
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@solana/rpc-types@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -9583,6 +9554,7 @@ snapshots:
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9598,6 +9570,7 @@ snapshots:
       '@solana/rpc-transformers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-transport-http': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9627,6 +9600,7 @@ snapshots:
       '@solana/offchain-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9634,6 +9608,7 @@ snapshots:
   '@solana/subscribable@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/sysvars@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -9644,11 +9619,12 @@ snapshots:
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/transaction-confirmation@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -9656,10 +9632,11 @@ snapshots:
       '@solana/keys': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 6.5.0(typescript@5.9.3)
       '@solana/rpc': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
@@ -9692,6 +9669,7 @@ snapshots:
       '@solana/instructions': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9728,6 +9706,7 @@ snapshots:
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -9747,7 +9726,7 @@ snapshots:
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
 
-  '@solana/web3.js@1.98.4(typescript@5.9.3)':
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@noble/curves': 1.9.7
@@ -9760,7 +9739,7 @@ snapshots:
       bs58: 4.0.1
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
-      jayson: 4.3.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       node-fetch: 2.7.0
       rpc-websockets: 9.3.6
       superstruct: 2.0.2
@@ -9787,15 +9766,16 @@ snapshots:
       '@tanstack/query-core': 5.91.2
       react: 19.2.0
 
-  '@testing-library/react-native@12.9.0(jest@29.7.0)(react-native@0.83.2)(react-test-renderer@19.2.4)(react@19.2.0)':
+  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@22.19.15))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react-test-renderer@19.2.4(react@19.2.0))(react@19.2.0)':
     dependencies:
-      jest: 29.7.0
       jest-matcher-utils: 29.7.0
       pretty-format: 29.7.0
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       react-test-renderer: 19.2.4(react@19.2.0)
       redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@22.19.15)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -9959,12 +9939,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1)':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10019,7 +10000,7 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
-  '@wallet-standard/react-core@1.0.1(react-dom@19.2.0)(react@19.2.0)':
+  '@wallet-standard/react-core@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
@@ -10031,9 +10012,9 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@wallet-standard/react@1.0.1(react-dom@19.2.0)(react@19.2.0)':
+  '@wallet-standard/react@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@wallet-standard/react-core': 1.0.1(react-dom@19.2.0)(react@19.2.0)
+      '@wallet-standard/react-core': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -10071,24 +10052,24 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
-  '@wallet-ui/core@4.0.1(@solana/kit@6.5.0)':
+  '@wallet-ui/core@4.0.1(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
       '@nanostores/persistent': 1.1.0(nanostores@1.0.1)
-      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit': 6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       nanostores: 1.0.1
 
-  '@wallet-ui/react-native-web3js@4.0.1(patch_hash=em4jhh3glyclnk3wmlyl3dpj3e)(@solana/kit@6.5.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)':
+  '@wallet-ui/react-native-web3js@4.0.1(patch_hash=423fyzrf6ef7pt2bnzr32iifq4)(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@nanostores/react': 1.1.0(nanostores@1.2.0)(react@19.2.0)
-      '@react-native-async-storage/async-storage': 2.2.0(react-native@0.83.2)
-      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2)(typescript@5.9.3)
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.6(@solana/web3.js@1.98.4)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2)(typescript@5.9.3)
+      '@react-native-async-storage/async-storage': 2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
       '@solana/react': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.0)(typescript@5.9.3)
       '@solana/wallet-standard-features': 1.3.0
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@wallet-standard/core': 1.1.1
-      '@wallet-standard/react': 1.0.1(react-dom@19.2.0)(react@19.2.0)
-      '@wallet-ui/core': 4.0.1(@solana/kit@6.5.0)
+      '@wallet-standard/react': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@wallet-ui/core': 4.0.1(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       js-base64: 3.7.8
       nanostores: 1.2.0
       react: 19.2.0
@@ -10332,16 +10313,17 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
       '@react-native/babel-preset': 0.83.2(@babel/core@7.29.0)
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
       debug: 4.4.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
       react-refresh: 0.14.2
       resolve-from: 5.0.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -10445,11 +10427,6 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  buffer@6.0.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -10458,6 +10435,7 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
+    optional: true
 
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
@@ -10695,7 +10673,7 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
-  create-jest@29.7.0:
+  create-jest@29.7.0(@types/node@22.19.15):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
@@ -10974,7 +10952,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  ethers@6.16.0:
+  ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -10982,7 +10960,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1
+      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11015,106 +10993,106 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expo-apple-authentication@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2):
+  expo-apple-authentication@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   expo-application@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-application@55.0.11-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
-  expo-asset@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
+  expo-asset@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13-canary-20260223-05214f1
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-blur@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-blur@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo-constants@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3):
+  expo-constants@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
       '@expo/env': 2.1.2-canary-20260223-05214f1
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-constants@55.0.10-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3):
+  expo-constants@55.0.10-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.12-canary-20260328-2049187(typescript@5.9.3)
       '@expo/env': 2.1.2-canary-20260328-2049187
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   expo-crypto@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
-  expo-file-system@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2):
+  expo-file-system@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo-font@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-font@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo-glass-effect@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-glass-effect@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
   expo-haptics@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
-  expo-image@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-image@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       sf-symbols-typescript: 2.2.0
 
   expo-keep-awake@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
 
-  expo-linear-gradient@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-linear-gradient@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo-linking@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
+  expo-linking@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
+      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
       invariant: 2.2.4
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -11129,66 +11107,67 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  expo-modules-core@55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0):
+  expo-modules-core@55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       invariant: 2.2.4
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo-notifications@55.0.15-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
+  expo-notifications@55.0.15-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13-canary-20260328-2049187
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-application: 55.0.11-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)
-      expo-constants: 55.0.10-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
+      expo-constants: 55.0.10-canary-20260328-2049187(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@55.0.0-canary-20260223-05214f1(@expo/log-box@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(@testing-library/react-native@12.9.0)(@types/react@19.2.14)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-linking@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-gesture-handler@2.30.0)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0):
+  expo-router@55.0.0-canary-20260223-05214f1(uyyophz2gdrjkjaoq6emi2a5pa):
     dependencies:
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)
+      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@expo/schema-utils': 55.0.0-canary-20260223-05214f1
       '@radix-ui/react-slot': 1.2.0(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-tabs': 1.1.13(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
-      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)
-      '@react-navigation/native': 7.1.28(react-native@0.83.2)(react@19.2.0)
-      '@react-navigation/native-stack': 7.10.1(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native@0.83.2)(react@19.2.0)
-      '@testing-library/react-native': 12.9.0(jest@29.7.0)(react-native@0.83.2)(react-test-renderer@19.2.4)(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native-stack': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
-      expo-glass-effect: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      expo-image: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      expo-linking: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
+      expo-glass-effect: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      expo-image: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      expo-linking: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-server: 55.0.0-canary-20260223-05214f1
-      expo-symbols: 55.0.0-canary-20260223-05214f1(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      expo-symbols: 55.0.0-canary-20260223-05214f1(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.11
       query-string: 7.1.3
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
       react-fast-compare: 3.2.2
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.2)(react@19.2.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2)(react@19.2.0)
-      react-native-reanimated: 4.2.3(react-native-worklets@0.7.2)(react-native@0.83.2)(react@19.2.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.2)(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
       use-latest-callback: 0.2.6(react@19.2.0)
-      vaul: 1.1.2(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    optionalDependencies:
+      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@22.19.15))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react-test-renderer@19.2.4(react@19.2.0))(react@19.2.0)
+      react-dom: 19.2.0(react@19.2.0)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-reanimated: 4.2.3(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -11198,7 +11177,7 @@ snapshots:
 
   expo-secure-store@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-server-sdk@6.1.0:
     dependencies:
@@ -11211,100 +11190,62 @@ snapshots:
   expo-splash-screen@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-status-bar@55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0):
+  expo-status-bar@55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
 
-  expo-symbols@55.0.0-canary-20260223-05214f1(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  expo-symbols@55.0.0-canary-20260223-05214f1(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.27
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       sf-symbols-typescript: 2.2.0
 
-  expo-web-browser@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2):
+  expo-web-browser@55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  expo@55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
+  expo@55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      '@expo/cli': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
       '@expo/config-plugins': 55.0.0-canary-20260223-05214f1
-      '@expo/devtools': 55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)
-      '@expo/dom-webview': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      '@expo/devtools': 55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@expo/fingerprint': 0.16.5-canary-20260223-05214f1
       '@expo/local-build-cache-provider': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/metro': 54.2.0
-      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
-      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native@0.83.2)(react@19.2.0)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)
+      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(bufferutil@4.1.0)(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
+      '@expo/vector-icons': 15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.0-canary-20260223-05214f1)(react-refresh@0.14.2)
-      expo-asset: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
-      expo-file-system: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
+      expo-asset: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(typescript@5.9.3)
+      expo-file-system: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))
+      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       expo-keep-awake: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react@19.2.0)
       expo-modules-autolinking: 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      expo-modules-core: 55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)
+      expo-modules-core: 55.0.0-canary-20260223-05214f1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       pretty-format: 29.7.0
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-webview: 13.16.0(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - expo-widgets
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  expo@55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo-constants@55.0.0-canary-20260223-05214f1)(expo-font@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/config-plugins': 55.0.0-canary-20260223-05214f1
-      '@expo/devtools': 55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)
-      '@expo/dom-webview': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/fingerprint': 0.16.5-canary-20260223-05214f1
-      '@expo/local-build-cache-provider': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      '@expo/log-box': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@expo/metro': 54.2.0
-      '@expo/metro-config': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(typescript@5.9.3)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      '@ungap/structured-clone': 1.3.0
-      babel-preset-expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.0-canary-20260223-05214f1)(react-refresh@0.14.2)
-      expo-asset: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(typescript@5.9.3)
-      expo-file-system: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)
-      expo-font: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0)
-      expo-keep-awake: 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react@19.2.0)
-      expo-modules-autolinking: 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
-      expo-modules-core: 55.0.0-canary-20260223-05214f1(react-native@0.83.2)(react@19.2.0)
-      pretty-format: 29.7.0
-      react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(react@19.2.0)
-      react-refresh: 0.14.2
-      whatwg-url-minimum: 0.1.1
+    optionalDependencies:
+      '@expo/dom-webview': 55.0.0-canary-20260223-05214f1(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      '@expo/metro-runtime': 55.0.0-canary-20260223-05214f1(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(expo@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-webview: 13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -11357,7 +11298,7 @@ snapshots:
       bser: 2.1.1
 
   fdir@6.5.0(picomatch@4.0.3):
-    dependencies:
+    optionalDependencies:
       picomatch: 4.0.3
 
   fetch-nodeshim@0.4.9: {}
@@ -11700,9 +11641,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@4.0.1(ws@7.5.10):
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)):
     dependencies:
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -11752,7 +11693,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  jayson@4.3.0:
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 12.20.55
@@ -11761,11 +11702,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10)
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11802,13 +11743,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
+  jest-cli@29.7.0(@types/node@22.19.15):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@22.19.15)
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.15)
@@ -11826,7 +11767,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
       babel-jest: 29.7.0(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -11846,6 +11786,8 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.15
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11869,7 +11811,7 @@ snapshots:
       jest-util: 29.7.0
       pretty-format: 29.7.0
 
-  jest-environment-jsdom@29.7.0:
+  jest-environment-jsdom@29.7.0(bufferutil@4.1.0):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
@@ -11878,7 +11820,7 @@ snapshots:
       '@types/node': 22.19.15
       jest-mock: 29.7.0
       jest-util: 29.7.0
-      jsdom: 20.0.3
+      jsdom: 20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11893,21 +11835,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(expo@55.0.0-canary-20260223-05214f1)(jest@29.7.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3):
+  jest-expo@55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@55.0.0-canary-20260223-05214f1)(jest@29.7.0(@types/node@22.19.15))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.0-canary-20260223-05214f1(typescript@5.9.3)
       '@expo/json-file': 10.0.13-canary-20260223-05214f1
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
-      jest-environment-jsdom: 29.7.0
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      jest-environment-jsdom: 29.7.0(bufferutil@4.1.0)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0)
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.19.15))
       json5: 2.2.3
       lodash: 4.17.23
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       react-test-renderer: 19.2.0(react@19.2.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -11970,7 +11912,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -12096,11 +12038,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.19.15)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.19.15)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -12125,12 +12067,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0:
+  jest@29.7.0(@types/node@22.19.15):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0
+      jest-cli: 29.7.0(@types/node@22.19.15)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12162,7 +12104,7 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jsdom@20.0.3:
+  jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       abab: 2.0.6
       acorn: 8.16.0
@@ -12295,7 +12237,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lottie-react@2.4.1(react-dom@19.2.0)(react@19.2.0):
+  lottie-react@2.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       lottie-web: 5.13.0
       react: 19.2.0
@@ -12396,12 +12338,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.3:
+  metro-config@0.83.3(bufferutil@4.1.0):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.83.3
+      metro: 0.83.3(bufferutil@4.1.0)
       metro-cache: 0.83.3
       metro-core: 0.83.3
       metro-runtime: 0.83.3
@@ -12411,12 +12353,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.83.5:
+  metro-config@0.83.5(bufferutil@4.1.0):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.83.5
+      metro: 0.83.5(bufferutil@4.1.0)
       metro-cache: 0.83.5
       metro-core: 0.83.5
       metro-runtime: 0.83.5
@@ -12567,14 +12509,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.83.3:
+  metro-transform-worker@0.83.3(bufferutil@4.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(bufferutil@4.1.0)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -12587,14 +12529,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-transform-worker@0.83.5:
+  metro-transform-worker@0.83.5(bufferutil@4.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.5
+      metro: 0.83.5(bufferutil@4.1.0)
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
@@ -12607,7 +12549,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.83.3:
+  metro@0.83.3(bufferutil@4.1.0):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -12633,7 +12575,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3
@@ -12641,20 +12583,20 @@ snapshots:
       metro-source-map: 0.83.3
       metro-symbolicate: 0.83.3
       metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
+      metro-transform-worker: 0.83.3(bufferutil@4.1.0)
       mime-types: 2.1.35
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
       throat: 5.0.0
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro@0.83.5:
+  metro@0.83.5(bufferutil@4.1.0):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -12680,7 +12622,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5
+      metro-config: 0.83.5(bufferutil@4.1.0)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5
@@ -12688,13 +12630,13 @@ snapshots:
       metro-source-map: 0.83.5
       metro-symbolicate: 0.83.5
       metro-transform-plugins: 0.83.5
-      metro-transform-worker: 0.83.5
+      metro-transform-worker: 0.83.5(bufferutil@4.1.0)
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
       throat: 5.0.0
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -12773,7 +12715,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@15.5.14(@babel/core@7.29.0)(react-dom@19.2.0)(react@19.2.0):
+  next@15.5.14(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 15.5.14
       '@swc/helpers': 0.5.15
@@ -12791,6 +12733,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.14
       '@next/swc-win32-arm64-msvc': 15.5.14
       '@next/swc-win32-x64-msvc': 15.5.14
+      babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -12808,7 +12751,8 @@ snapshots:
 
   node-forge@1.3.3: {}
 
-  node-gyp-build@4.8.4: {}
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -13011,16 +12955,23 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
       jiti: 1.21.7
-      lilconfig: 3.1.3
       postcss: 8.5.8
+      tsx: 4.21.0
+      yaml: 2.8.3
 
-  postcss-load-config@6.0.1(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.8
       tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss-nested@6.2.0(postcss@8.5.8):
     dependencies:
@@ -13064,6 +13015,7 @@ snapshots:
     dependencies:
       '@prisma/config': 6.19.2
       '@prisma/engines': 6.19.2
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - magicast
@@ -13123,10 +13075,10 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
 
-  react-devtools-core@6.1.5:
+  react-devtools-core@6.1.5(bufferutil@4.1.0):
     dependencies:
       shell-quote: 1.8.3
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -13148,71 +13100,71 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-gesture-handler@2.30.0(react-native@0.83.2)(react@19.2.0):
+  react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-get-random-values@1.11.0(react-native@0.83.2):
+  react-native-get-random-values@1.11.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)):
     dependencies:
       fast-base64-decode: 1.0.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.83.2)(react@19.2.0):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-pager-view@8.0.0(react-native@0.83.2)(react@19.2.0):
+  react-native-pager-view@8.0.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-passkeys@0.4.0(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2)(react@19.2.0):
+  react-native-passkeys@0.4.0(expo@55.0.0-canary-20260223-05214f1)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
-      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0)(react-native-webview@13.16.0)(react-native@0.83.2)(react@19.2.0)(typescript@5.9.3)
+      expo: 55.0.0-canary-20260223-05214f1(@babel/core@7.29.0)(@expo/dom-webview@55.0.0-canary-20260223-05214f1)(@expo/metro-runtime@55.0.0-canary-20260223-05214f1)(bufferutil@4.1.0)(expo-router@55.0.0-canary-20260223-05214f1)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-reanimated@4.2.3(react-native-worklets@0.7.2)(react-native@0.83.2)(react@19.2.0):
+  react-native-reanimated@4.2.3(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2)(react@19.2.0)
-      react-native-worklets: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      react-native-worklets: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
       semver: 7.7.4
 
-  react-native-safe-area-context@5.6.2(react-native@0.83.2)(react@19.2.0):
+  react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-screens@4.23.0(react-native@0.83.2)(react@19.2.0):
+  react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-freeze: 1.0.4(react@19.2.0)
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       warn-once: 0.1.1
 
-  react-native-svg@15.15.4(react-native@0.83.2)(react@19.2.0):
+  react-native-svg@15.15.4(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       warn-once: 0.1.1
 
-  react-native-webview@13.16.0(react-native@0.83.2)(react@19.2.0):
+  react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
 
-  react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2)(react@19.2.0):
+  react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -13226,96 +13178,51 @@ snapshots:
       '@babel/preset-typescript': 7.27.1(@babel/core@7.29.0)
       convert-source-map: 2.0.0
       react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0):
+  react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.83.2
       '@react-native/codegen': 0.83.2(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.83.2
+      '@react-native/community-cli-plugin': 0.83.2(bufferutil@4.1.0)
       '@react-native/gradle-plugin': 0.83.2
       '@react-native/js-polyfills': 0.83.2
       '@react-native/normalize-colors': 0.83.2
-      '@react-native/virtualized-lists': 0.83.2(@types/react@19.2.14)(react-native@0.83.2)(react@19.2.0)
+      '@react-native/virtualized-lists': 0.83.2(@types/react@19.2.14)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0))(react@19.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.32.0
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      hermes-compiler: 0.14.1
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.83.5
+      metro-source-map: 0.83.5
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.2.0
+      react-devtools-core: 6.1.5(bufferutil@4.1.0)
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.27.0
+      semver: 7.7.4
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      yargs: 17.7.2
+    optionalDependencies:
       '@types/react': 19.2.14
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      babel-plugin-syntax-hermes-parser: 0.32.0
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      glob: 7.2.3
-      hermes-compiler: 0.14.1
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.83.5
-      metro-source-map: 0.83.5
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.2.0
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.27.0
-      semver: 7.7.4
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  react-native@0.83.2(@babel/core@7.29.0)(react@19.2.0):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.83.2
-      '@react-native/codegen': 0.83.2(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.83.2
-      '@react-native/gradle-plugin': 0.83.2
-      '@react-native/js-polyfills': 0.83.2
-      '@react-native/normalize-colors': 0.83.2
-      '@react-native/virtualized-lists': 0.83.2(react-native@0.83.2)(react@19.2.0)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      babel-plugin-syntax-hermes-parser: 0.32.0
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      glob: 7.2.3
-      hermes-compiler: 0.14.1
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.83.5
-      metro-source-map: 0.83.5
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.2.0
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.27.0
-      semver: 7.7.4
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-      ws: 7.5.10
-      yargs: 17.7.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -13328,27 +13235,30 @@ snapshots:
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.0):
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
       react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.0)
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.0):
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.0)
       react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.0)
       tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.0)
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.0):
     dependencies:
-      '@types/react': 19.2.14
       get-nonce: 1.0.1
       react: 19.2.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-test-renderer@19.2.0(react@19.2.0):
     dependencies:
@@ -13362,9 +13272,10 @@ snapshots:
       react-is: 19.2.4
       scheduler: 0.27.0
 
-  react-use-measure@2.1.7(react-dom@19.2.0)(react@19.2.0):
+  react-use-measure@2.1.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
+    optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
 
   react@19.2.0: {}
@@ -13777,9 +13688,10 @@ snapshots:
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.0):
     dependencies:
-      '@babel/core': 7.29.0
       client-only: 0.0.1
       react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -13818,7 +13730,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -13837,7 +13749,7 @@ snapshots:
       postcss: 8.5.8
       postcss-import: 15.1.0(postcss@8.5.8)
       postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.8)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -13954,7 +13866,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -13965,7 +13877,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.59.1
       source-map: 0.7.6
@@ -13973,6 +13885,8 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -14050,9 +13964,10 @@ snapshots:
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.0):
     dependencies:
-      '@types/react': 19.2.14
       react: 19.2.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-latest-callback@0.2.6(react@19.2.0):
     dependencies:
@@ -14060,10 +13975,11 @@ snapshots:
 
   use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.0):
     dependencies:
-      '@types/react': 19.2.14
       detect-node-es: 1.1.0
       react: 19.2.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
@@ -14072,6 +13988,7 @@ snapshots:
   utf-8-validate@6.0.6:
     dependencies:
       node-gyp-build: 4.8.4
+    optional: true
 
   util-deprecate@1.0.2: {}
 
@@ -14103,22 +14020,22 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul@1.1.2(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0):
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
 
-  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14133,25 +14050,28 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      '@types/node': 22.19.15
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.8
       rollup: 4.59.1
       tinyglobby: 0.2.15
-      tsx: 4.21.0
     optionalDependencies:
+      '@types/node': 22.19.15
       fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
-      '@types/node': 22.19.15
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1)
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14169,9 +14089,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+      jsdom: 20.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - jiti
       - less
@@ -14262,12 +14185,18 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@7.5.10: {}
+  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
-  ws@8.17.1: {}
+  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
+    optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
@@ -14320,12 +14249,13 @@ snapshots:
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.0):
     dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0):
-    dependencies:
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
+    optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)


### PR DESCRIPTION
## Summary
- Copy `patches/` directory in Dockerfile before `pnpm install` so the `@wallet-ui/react-native-web3js@4.0.1` patch is available inside the container
- Regenerate `pnpm-lock.yaml` to sync a stale patch hash (`em4jhh3glyclnk3wmlyl3dpj3e` → `423fyzrf6ef7pt2bnzr32iifq4`) that was causing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`

Both staging and production Railway deployments were failing with 404 ("Application not found") because the last few builds errored during `pnpm install`. Staging is already green after these two commits landed on `stage`.

## Test plan
- [x] Staging build on Railway succeeds (`mintfeed-api` → SUCCESS)
- [x] `GET https://mintfeed-api-staging.up.railway.app/api/v1/health` returns `{"status":"ok"}`
- [ ] Production build on Railway succeeds after merge
- [ ] `GET https://mintfeed-api-production.up.railway.app/api/v1/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)